### PR TITLE
Feature/add robust pipeline schema usage

### DIFF
--- a/pipelines/components/firestore_export.py
+++ b/pipelines/components/firestore_export.py
@@ -31,7 +31,7 @@ def firestore_export_op(firestore_database: str, firestore_collection: str, expo
 
     # Check if the directory exists and delete it if it does
     bucket = storage_client.bucket(export_bucket)
-    blobs = bucket.list_blobs(prefix=export_path)
+    blobs = bucket.list_blobs(prefix=f"firestore-exports/{organisation_identifier}-{platform}")
     for blob in blobs:
         blob.delete()
     print(f"Deleted existing files in {gcs_path}")

--- a/pipelines/components/transform_android.py
+++ b/pipelines/components/transform_android.py
@@ -144,7 +144,7 @@ def bigquery_raw_data_to_typed_data_op(raw_data_table: str, updates_table: str, 
     print(f"BigQuery: start transforming raw data to typed data")
     bigquery_client = bigquery.Client(project=project_name)
 
-    # Update schema if necessary
+    # Update schema
     raw_data_table_ref = bigquery.TableReference.from_string(raw_data_table, default_project=project_name)
     update_table_schema(raw_data_table_ref)
 

--- a/pipelines/requirements.txt
+++ b/pipelines/requirements.txt
@@ -1,2 +1,2 @@
 kfp==1.7.0
-google.cloud.aiplatform==1.8.0
+google.cloud.aiplatform==1.21.0


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

This PR contains two changes:
- We currently don't enforce completeness of the API schema. Since the schema of the available data in a given organisation propagates throughout the pipeline we ran into an issue where we're trying to build a BQ query that fails since certain fields were missing. The component impacted was the transform step and all subsequent component also couldn't deal with the absence of certain fields. One field missing from the organisation I'm setting up was `previousMeasurement`. It had previously never happened that a Firestore collection didn't contain any instance of this field but this case shouldn't be breaking for the pipeline. There was also at least one field missing from within the previous/current measurement struct. While these fields are nullable they should still exist in the schema for the queries to properly function.
- Currently we ran into an issue where, for some reason, the firestore exort request file didn't get cleaned up properly. To this end we updated the `firestore_export` component to always start of with clearing the directory in the storage container of any remaining files.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- This has been tested by running a pipeline job for the newly added organisation which has missing fields for both operating systems


