### PR TITLE
Add "delete old data" pipeline step

### DIFF
--- a/pipelines/components/delete_old_data.py
+++ b/pipelines/components/delete_old_data.py
@@ -1,0 +1,42 @@
+from kfp.dsl import component
+
+@component(
+    packages_to_install=["google-cloud-bigquery==3.27.0"],
+    base_image="python:3.13"
+)
+def delete_old_data(events_table: str, aggregation_table: str, project_name: str):
+    from datetime import datetime, timedelta
+    from google.cloud import bigquery
+
+    # 365 days ago
+    one_year_ago = (datetime.now() - timedelta(days=365)).timestamp()
+
+    def delete_old_data_from_events_table():
+        return f"""
+                DELETE FROM `{events_table}`
+                WHERE currentMeasurement.stats_timestamp < "{one_year_ago}"
+        """
+
+    def delete_old_data_from_aggregation_table():
+        return f"""
+                DELETE FROM `{aggregation_table}`
+                WHERE stats_timestamp < "{one_year_ago}"
+        """
+
+    bigquery_client = bigquery.Client(project=project_name)
+
+    print(f"BigQuery: start deleting rows older than 365 days from {events_table}")
+    query = delete_old_data_from_events_table()
+    # Start the query
+    query_job = bigquery_client.query(query)
+    result = query_job.result()
+
+    print(f"Deleted {result.total_rows} rows from {events_table}")
+
+    print(f"BigQuery: start deleting rows older than 365 days from {aggregation_table}")
+    query = delete_old_data_from_aggregation_table()
+    # Start the query
+    query_job = bigquery_client.query(query)
+    result = query_job.result()
+
+    print(f"Deleted {result.total_rows} rows from {aggregation_table}")

--- a/pipelines/pipelines/pipeline_android.py
+++ b/pipelines/pipelines/pipeline_android.py
@@ -13,6 +13,7 @@ from components.cleanup_bigquery_structured_data_intermediate import \
 from components.aggregate_android import bigquery_aggregate_events_op
 from components.storage_move_files import storage_move_files_op
 from components.add_custom_properties import bigquery_add_custom_properties
+from components.delete_old_data import delete_old_data
 
 """
     Define pipeline.
@@ -152,5 +153,12 @@ def pipeline_android(
     # clean up transformed dataset in bigquery
     cleanup_bigquery_structured_data_intermediate(
         structured_data_table=transform_result.output,
+        project_name=project_name
+    ).after(aggregate_result, merge_result)
+
+    # delete data older than 365 days
+    delete_old_data(
+        events_table=events_table,
+        aggregation_table=aggregation_table,
         project_name=project_name
     ).after(aggregate_result, merge_result)

--- a/pipelines/pipelines/pipeline_ios.py
+++ b/pipelines/pipelines/pipeline_ios.py
@@ -12,6 +12,7 @@ from components.cleanup_bigquery_structured_data_intermediate import \
     cleanup_bigquery_structured_data_intermediate
 from components.aggregate_ios import bigquery_aggregate_events_op
 from components.storage_move_files import storage_move_files_op
+from components.delete_old_data import delete_old_data
 
 
 """
@@ -147,5 +148,12 @@ def pipeline_ios(
     # clean up transformed dataset in bigquery
     cleanup_bigquery_structured_data_intermediate(
         structured_data_table=transform_result.output,
+        project_name=project_name
+    ).after(aggregate_result, merge_result)
+
+    # delete data older than 365 days
+    delete_old_data(
+        events_table=events_table,
+        aggregation_table=aggregation_table,
         project_name=project_name
     ).after(aggregate_result, merge_result)


### PR DESCRIPTION
# Description

Adds a new pipeline step which removes data older than 365 days from the event data and aggregated data bigquery tables.


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)




